### PR TITLE
feat(articles): add article status management with draft and publish …

### DIFF
--- a/prisma/migrations/20250723043222_update_article_status/migration.sql
+++ b/prisma/migrations/20250723043222_update_article_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Article` ADD COLUMN `status` ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Article {
   title       String
   description String
   body        String   @db.Text
+  status      ArticleStatus @default(DRAFT)
   tagList     Tag[]    @relation("ArticleTags")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -66,4 +67,9 @@ model Comment {
 
   articleId      Int
   article        Article    @relation(fields: [articleId], references: [id])
+}
+
+enum ArticleStatus {
+	DRAFT
+	PUBLISHED
 }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -20,6 +20,8 @@ import { ArticleOwnerGuard } from 'src/common/guards/article-owner.guard';
 import { Public } from 'src/auth/constants';
 import { Language } from '../i18n/decorators/language.decorator';
 import { PublishArticlesDto } from './dto/publish-article.dto';
+import { DraftArticlesResponseDto } from './dto/draft-articles-response.dto';
+import { PublishArticlesResponseDto } from './dto/publish-articles-response.dto';
 
 @Controller('articles')
 export class ArticlesController {
@@ -35,7 +37,7 @@ export class ArticlesController {
   }
 
   @Get('drafts')
-  getDraftArticles(@CurrentUser() currentUser: User) {
+  getDraftArticles(@CurrentUser() currentUser: User): Promise<DraftArticlesResponseDto> {
     return this.articlesService.getDraftArticles(currentUser);
   }
 
@@ -88,10 +90,10 @@ export class ArticlesController {
   @Post('publish')
   publishArticles(
     @CurrentUser() currentUser: User,
-    @Body() publishArticlesDto: PublishArticlesDto,
-    @Language() lang: string,
-  ) {
-    return this.articlesService.publishArticles(currentUser, publishArticlesDto, lang);
+    @Body() publishData: PublishArticlesDto,
+    @Language() language: string,
+  ): Promise<PublishArticlesResponseDto> {
+    return this.articlesService.publishArticles(currentUser, publishData, language);
   }
 
   @Patch(':slug/status')

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,11 +1,17 @@
-import { User } from './../../generated/prisma/index.d';
-import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { ArticleStatus, User } from '../../generated/prisma/index';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateArticleDto } from './dto/create-article.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
 import slugify from 'slugify';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ListArticlesDto } from './dto/list-articles.dto';
 import { I18nService } from '../i18n/i18n.service';
+import { PublishArticlesDto } from './dto/publish-article.dto';
 
 interface TagListOperations {
   connect: { id: number }[];
@@ -72,6 +78,7 @@ export class ArticlesService {
       description: createArticleDto.description,
       body: createArticleDto.body,
       slug: slug,
+      status: ArticleStatus.DRAFT,
       author: {
         connect: {
           id: author.id,
@@ -88,10 +95,87 @@ export class ArticlesService {
     return this.buildArticleResponse(author, article);
   }
 
-  async findOne(slug: string, lang?: string) {
+  async getDraftArticles(currentUser: User) {
+    const articles = await this.prisma.article.findMany({
+      where: {
+        authorId: currentUser.id,
+        status: 'DRAFT',
+      },
+      include: this.getArticleIncludeOptions(),
+      orderBy: {
+        updatedAt: 'desc',
+      },
+    });
+
+    return {
+      articles: articles.map((article) => this.buildArticleResponse(currentUser, article)),
+      articlesCount: articles.length,
+    };
+  }
+
+  async publishArticles(currentUser: User, data: PublishArticlesDto, lang?: string) {
+    // Check if all articles belong to the user and are in draft status
+    const articles = await this.prisma.article.findMany({
+      where: {
+        slug: { in: data.articleSlugs },
+        authorId: currentUser.id,
+        status: 'DRAFT',
+      },
+    });
+
+    if (articles.length !== data.articleSlugs.length) {
+      throw new NotFoundException(
+        this.i18nService.getArticleMessage('errors.someArticlesNotFound', lang),
+      );
+    }
+
+    // Publish all articles
+    await this.prisma.article.updateMany({
+      where: {
+        slug: { in: data.articleSlugs },
+        authorId: currentUser.id,
+      },
+      data: {
+        status: 'PUBLISHED',
+      },
+    });
+
+    return {
+      message: this.i18nService.getArticleMessage('success.published', lang, {
+        count: articles.length,
+      }),
+    };
+  }
+  async updateArticleStatus(currentUser: User, slug: string, status: ArticleStatus, lang?: string) {
+    const article = await this.prisma.article.findUnique({
+      where: { slug },
+    });
+
+    if (!article) {
+      throw new NotFoundException(this.i18nService.getArticleMessage('errors.notFound', lang));
+    }
+
+    const updatedArticle = await this.prisma.article.update({
+      where: { slug },
+      data: {
+        status,
+      },
+      include: this.getArticleIncludeOptions(),
+    });
+
+    const author = await this.findArticleAuthor(article.authorId);
+
+    return this.buildArticleResponse(author, updatedArticle);
+  }
+
+  async findOne(currUser: User, slug: string, lang?: string) {
     const article = await this.getArticleWithCounts({ slug });
 
     if (!article) {
+      throw new BadRequestException(this.i18nService.getArticleMessage('errors.notFound', lang));
+    }
+
+    if (article.status === 'DRAFT' && (!currUser || article.authorId !== currUser.id)) {
       throw new BadRequestException(this.i18nService.getArticleMessage('errors.notFound', lang));
     }
 
@@ -242,7 +326,10 @@ export class ArticlesService {
       tagList?: { some: { name: { in: string[] } } };
       author?: { username: { in: string[] } };
       favoritedBy?: { some: { username: string } };
-    } = {};
+      status: ArticleStatus;
+    } = {
+      status: ArticleStatus.PUBLISHED,
+    };
 
     if (listArticleDTO.tag) {
       const tags = listArticleDTO.tag.split(',').map((tag) => tag.trim());

--- a/src/articles/dto/draft-articles-response.dto.ts
+++ b/src/articles/dto/draft-articles-response.dto.ts
@@ -1,0 +1,4 @@
+export class DraftArticlesResponseDto {
+  articles: any[];
+  articlesCount: number;
+}

--- a/src/articles/dto/publish-article.dto.ts
+++ b/src/articles/dto/publish-article.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class PublishArticlesDto {
+  @IsArray()
+  @IsString({ each: true })
+  articleSlugs: string[];
+}
+
+export class UpdateArticleStatusDto {
+  @IsOptional()
+  @IsString()
+  status?: 'DRAFT' | 'PUBLISHED';
+}

--- a/src/articles/dto/publish-articles-response.dto.ts
+++ b/src/articles/dto/publish-articles-response.dto.ts
@@ -1,0 +1,3 @@
+export class PublishArticlesResponseDto {
+  message: string;
+}

--- a/src/i18n/en/article.json
+++ b/src/i18n/en/article.json
@@ -1,17 +1,19 @@
 {
   "errors": {
-    "titleExists": "Article with title \"{{title}}\" already exists",
+    "titleExists": "Article with title {title} already exists",
     "notFound": "Article not found",
     "authorNotFound": "Article author not found",
     "alreadyFavorited": "Already favorited this article",
-    "notFavorited": "Article not favorited yet"
+    "notFavorited": "Article not favorited yet",
+    "someArticlesNotFound": "Some articles not found or already published"
   },
   "success": {
     "created": "Article created successfully",
     "updated": "Article updated successfully",
     "deleted": "Article deleted successfully",
     "favorited": "Article favorited successfully",
-    "unfavorited": "Article unfavorited successfully"
+    "unfavorited": "Article unfavorited successfully",
+    "published": "Successfully published {count} articles"
   },
   "validation": {
     "titleRequired": "Title is required",

--- a/src/i18n/en/user.json
+++ b/src/i18n/en/user.json
@@ -1,13 +1,13 @@
 {
   "errors": {
     "notFound": "User not found",
-    "emailExists": "User with email \"{{email}}\" already exists",
-    "usernameExists": "Username \"{{username}}\" is already taken",
-    "profileNotFound": "User with username \"{{username}}\" not found",
+    "emailExists": "User with email {email} already exists",
+    "usernameExists": "Username {username} is already taken",
+    "profileNotFound": "User with username {username} not found",
     "cannotFollowSelf": "You cannot follow yourself",
     "cannotUnfollowSelf": "You cannot unfollow yourself",
-    "alreadyFollowing": "You are already following {{username}}",
-    "notFollowing": "You are not following {{username}}",
+    "alreadyFollowing": "You are already following {username}",
+    "notFollowing": "You are not following {username}",
     "cannotUpdateUser": "Cannot update user information",
     "invalidUserData": "Invalid user data provided"
   },

--- a/src/i18n/vi/article.json
+++ b/src/i18n/vi/article.json
@@ -1,17 +1,19 @@
 {
   "errors": {
-    "titleExists": "Bài viết với tiêu đề \"{{title}}\" đã tồn tại",
+    "titleExists": "Bài viết với tiêu đề {title} đã tồn tại",
     "notFound": "Không tìm thấy bài viết",
     "authorNotFound": "Không tìm thấy tác giả của bài viết",
     "alreadyFavorited": "Đã yêu thích bài viết này rồi",
-    "notFavorited": "Bài viết chưa được yêu thích"
+    "notFavorited": "Bài viết chưa được yêu thích",
+    "someArticlesNotFound": "Không tìm thấy một số bài viết, có thể không tồn tại hoặc đã xuất bản"
   },
   "success": {
     "created": "Tạo bài viết thành công",
     "updated": "Cập nhật bài viết thành công",
     "deleted": "Xóa bài viết thành công",
     "favorited": "Yêu thích bài viết thành công",
-    "unfavorited": "Bỏ yêu thích bài viết thành công"
+    "unfavorited": "Bỏ yêu thích bài viết thành công",
+    "published": "Xuất bản thành công {count} bài viết"
   },
   "validation": {
     "titleRequired": "Tiêu đề là bắt buộc",

--- a/src/i18n/vi/user.json
+++ b/src/i18n/vi/user.json
@@ -1,13 +1,13 @@
 {
   "errors": {
     "notFound": "Không tìm thấy người dùng",
-    "emailExists": "Người dùng với email \"{{email}}\" đã tồn tại",
-    "usernameExists": "Tên đăng nhập \"{{username}}\" đã được sử dụng",
-    "profileNotFound": "Không tìm thấy người dùng với tên \"{{username}}\"",
+    "emailExists": "Người dùng với email {email} đã tồn tại",
+    "usernameExists": "Tên đăng nhập {username} đã được sử dụng",
+    "profileNotFound": "Không tìm thấy người dùng với tên {username}",
     "cannotFollowSelf": "Bạn không thể theo dõi chính mình",
     "cannotUnfollowSelf": "Bạn không thể bỏ theo dõi chính mình",
-    "alreadyFollowing": "Bạn đã theo dõi {{username}} rồi",
-    "notFollowing": "Bạn chưa theo dõi {{username}}",
+    "alreadyFollowing": "Bạn đã theo dõi {username} rồi",
+    "notFollowing": "Bạn chưa theo dõi {{username}",
     "cannotUpdateUser": "Không thể cập nhật thông tin người dùng",
     "invalidUserData": "Dữ liệu người dùng không hợp lệ"
   },


### PR DESCRIPTION
This pull request introduces a new `status` field for articles, enabling better management of article states (`DRAFT` or `PUBLISHED`). It includes database schema updates, API enhancements, and service logic changes to support draft and publish workflows. Below is a summary of the key changes:

### Database and Schema Updates
* Added a `status` column to the `Article` table with an ENUM type (`DRAFT`, `PUBLISHED`) and a default value of `DRAFT`. (`[prisma/migrations/20250723043222_update_article_status/migration.sqlR1-R2](diffhunk://#diff-dd872782c73fd0bcaa7e3d1b6d595599be385e632536bb8f4dba065b137157ceR1-R2)`)
* Updated the Prisma schema to include the `status` field in the `Article` model and defined a new `ArticleStatus` enum. (`[[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR41)`, `[[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR71-R75)`)

### API Enhancements
* Added new endpoints in `ArticlesController`:
  - [`GET /articles/drafts`](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96): Fetches draft articles for the current user. (`[src/articles/articles.controller.tsR72-R96](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96)`)
  - [`POST /articles/publish`](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96): Publishes multiple draft articles. (`[src/articles/articles.controller.tsR72-R96](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96)`)
  - [`PATCH /articles/:slug/status`](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96): Updates the status of a specific article. (`[src/articles/articles.controller.tsR72-R96](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66R72-R96)`)
* Modified the `GET /articles/:slug` endpoint to restrict access to drafts unless the current user is the author. (`[src/articles/articles.controller.tsL27-R29](diffhunk://#diff-eb1bf355c3a12ca388fe6f758942c7cf8509d058e7bd3893bb616ed655f17b66L27-R29)`)

### Service Logic Changes
* Updated `ArticlesService` to:
  - Set the default status to `DRAFT` when creating articles. (`[src/articles/articles.service.tsR81](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbR81)`)
  - Implement methods for fetching drafts, publishing articles, and updating article statuses. (`[[1]](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbL91-R181)`, `[[2]](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbL245-R332)`)
  - Ensure drafts are only visible to their authors. (`[src/articles/articles.service.tsL91-R181](diffhunk://#diff-64418787047e7e62140edd54a32b502fb9638f22737963c5acb93c36a5161ecbL91-R181)`)

### DTO and Validation Updates
* Added `PublishArticlesDto` and `UpdateArticleStatusDto` to validate payloads for publishing and updating article statuses. (`[src/articles/dto/publish-article.dto.tsR1-R13](diffhunk://#diff-077d02b3db05fdc8e37593667ea8ddf897dd71bc5d1c86a42d21f5b042527d98R1-R13)`)

### Localization Updates
* Added new error and success messages for draft and publish workflows in English and Vietnamese localization files. (`[[1]](diffhunk://#diff-6df1ff82e8aa846a2a18c65afabb88a52de41e3bd783a1cc72e61e286db2da52L7-R16)`, `[[2]](diffhunk://#diff-c8ba6bec7c8f15e23c488c16204e7024f7cadc9ea3e4b4366ee7d12870e1c78cL7-R16)`)…functionality